### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"author": "changchang <changchang005@gmail.com>", 
 	"version": "0.0.5", 
 	"description": "A simple tool to keep requests to be executed in order.", 
+	"license": "MIT",
 	"homepage": "https://github.com/changchang/seq-queue", 
 	"repository": {
 		"type": "git", 


### PR DESCRIPTION
LICENSE is present in git repo but not in `package.json`, this causes [npmjs.com](https://www.npmjs.com/package/seq-queue) and various tools to display `license: none` instead of the correct license.